### PR TITLE
Remove issue title from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,7 +1,6 @@
 ---
 name: Report a bug, issue or concern
 about: Use this template for tor submitting issues
-title: "[DATE]: [VWS/Covid19NotificationApp]"
 ---
 ### Describe the bug, issue or concern
 


### PR DESCRIPTION
The issue template contained a title with a date and some template repo name. Users submitting issues do not quite get this and thus it results into noise. I think it's better to leave it out for now and edit the issue title after the issue is created if required.